### PR TITLE
feat: 회원탈퇴 api 구현

### DIFF
--- a/src/constants/responseMessage.js
+++ b/src/constants/responseMessage.js
@@ -7,4 +7,9 @@ module.exports = {
 
   //통계
   GET_LOG_SUCCESS: "이용 통계 조회 성공",
+
+  //사용자
+  SIGNUP_SUCCESS: "signup success",
+  SIGNOUT_SUCCESS: "signout success",
+  SIGNIN_SUCCESS: "signin success"
 };

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -12,12 +12,12 @@ const userService = require("../services/userService");
 const signup = async (req, res) => {
     const { name, age, email, password, gender, phone } = req.body
     if( !name || !age || !email || !password || !gender || !phone ) {
-        return  res.send(
+        return  res.status(statusCode.BAD_REQUEST).send(
             util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE)
         );
     }
     await userService.signup(name, age, email, password, gender, phone)
-    res.send(
+    res.status(statusCode.CREATED).send(
         util.success(statusCode.CREATED, responseMessage.SIGNUP_SUCCESS)
     );
 }
@@ -43,14 +43,14 @@ const signin = async (req, res) => {
 const signout = async (req, res) => {
     const { email, password } = req.query
     if( !email || !password ) {
-        return res.send(
+        return res.status(statusCode.BAD_REQUEST).send(
             util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE)
         );
     }
 
     await userService.signout(email, password)
-    res.send(
-        util.success(statusCode.CREATED, responseMessage.SIGNOUT_SUCCESS)
+    res.status(statusCode.NO_CONTENT).send(
+        util.success(statusCode.NO_CONTENT)
     );
 }
 

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,25 +1,61 @@
+const responseMessage = require("../constants/responseMessage");
+const statusCode = require("../constants/statusCode");
+const util = require("../lib/util");
 const userService = require("../services/userService");
 
+/**
+ *  @사용자_회원가입
+ *  @route POST /user/signup
+ *  @access public
+ *  @err
+ */
 const signup = async (req, res) => {
     const { name, age, email, password, gender, phone } = req.body
     if( !name || !age || !email || !password || !gender || !phone ) {
-        return  res.status(400).json({"message": "빈칸없이 모두 입력해주세요"});
+        return  res.send(
+            util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE)
+        );
     }
     await userService.signup(name, age, email, password, gender, phone)
-    res.status(200).json({"message": "signup success"})
+    res.send(
+        util.success(statusCode.CREATED, responseMessage.SIGNUP_SUCCESS)
+    );
 }
 
+/**
+ *  @사용자_로그인
+ *  @route GET user/signin
+ *  @access public
+ *  @err
+ */
 const signin = async (req, res) => {
+    const {email, password } = req.query
+    const token = await userService.signin(email, password)
+    res.status(statusCode.OK).json({"message": responseMessage.SIGNIN_SUCCESS, "accessToken": token});
+}
+
+/**
+ *  @사용자_회원탈퇴
+ *  @route POST user/signout
+ *  @access public
+ *  @err
+ */
+const signout = async (req, res) => {
     const { email, password } = req.query
     if( !email || !password ) {
-        return res.status(400).json({"message":"빈칸없이 모두 입력해주세요"})
+        return res.send(
+            util.fail(statusCode.BAD_REQUEST, responseMessage.NULL_VALUE)
+        );
     }
 
-    const token = await userService.signin(email, password)
-    res.status(200).json({"message": "signin success", "accessToken": token});
+    await userService.signout(email, password)
+    res.send(
+        util.success(statusCode.CREATED, responseMessage.SIGNOUT_SUCCESS)
+    );
 }
 
 module.exports = {
-    signup,
-    signin
+    signout,
+    signin,
+    signup
 }

--- a/src/models/userDao.js
+++ b/src/models/userDao.js
@@ -1,5 +1,6 @@
 const { AppDataSource } = require("./datasource");
 const { v4: uuid } = require('uuid');
+const Error = require("../middlewares/errorConstructor");
 
 const signup = async (name, age, email, hashedPassword, gender, phone) => {
     const userId = uuid();
@@ -61,6 +62,24 @@ const checkPassword = async (email) => {
     )
 }
 
+const deleteUser = async (email) => {
+    try {
+        return await AppDataSource.query(
+            `
+            UPDATE user 
+            SET 
+            name = "null",
+            password = "null",
+            email = "null",
+            phone = "null"
+            WHERE email="${email}"
+            `
+        )
+    } catch (err) {
+        throw new Error("SERVER ERROR", 500)
+    }
+}
+
 
 
 module.exports = {
@@ -69,5 +88,7 @@ module.exports = {
     checkGradeByEmail,
     getUserGradeByEmail,
     getUserIdByEmail,
+    deleteUser,
+    checkEmail,
     checkPassword
 }

--- a/src/routes/userRouter.js
+++ b/src/routes/userRouter.js
@@ -5,6 +5,7 @@ const userController = require("../controllers/userController");
 
 router.post("/signup", userController.signup);
 router.get("/signin", userController.signin);
+router.post("/signout", userController.signout);
 
 module.exports = {
     router

--- a/src/routes/userRouter.js
+++ b/src/routes/userRouter.js
@@ -5,7 +5,7 @@ const userController = require("../controllers/userController");
 
 router.post("/signup", userController.signup);
 router.get("/signin", userController.signin);
-router.post("/signout", userController.signout);
+router.patch("/signout", userController.signout);
 
 module.exports = {
     router

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,5 +1,6 @@
 const checkUserSignup = require("../utils/userSignupValidate");
 const checkUserSignin = require("../utils/userSigninValidate");
+const checkUserSignout = require("../utils/userSignoutValidate");
 
 const signup = async (name, age, email, password, gender, phone) => {
     await checkUserSignup.signup(name, age, email, password, gender, phone);
@@ -11,7 +12,13 @@ const signin = async (email, password) => {
     return token;
 }
 
+const signout = async (email, password) => {
+    const result = await checkUserSignout.signout(email, password);
+    return result;
+}
+
 module.exports = {
     signup,
-    signin
+    signin,
+    signout
 }

--- a/src/utils/userSignoutValidate.js
+++ b/src/utils/userSignoutValidate.js
@@ -1,0 +1,24 @@
+const userDao = require("../models/userDao");
+const bcrypt = require("bcrypt");
+
+const signout = async (email, password) => {
+    const existsCheck = await userDao.checkEmail(email);
+    const checkResult = JSON.stringify(Object.values(existsCheck[0])[0]);
+    const ResultEmail = checkResult.replace(/\"/gi, '');
+    if (ResultEmail == 0) {
+        throw new Error("KEY ERROR", 400);
+    }
+
+    const getBcrypt = await userDao.checkPassword(email);
+    const decode = await bcrypt.compare(password, getBcrypt[0].password);
+    if (!decode) {
+        throw new Error("KEY ERROR", 400);
+    }
+
+    await userDao.deleteUser(email)
+    return true;
+}
+
+module.exports = {
+    signout
+}


### PR DESCRIPTION
# 구현사항

## 회원탈퇴 API
사용자의 이메일, 패스워드를 전송하면 유효성 검증 후 

name, phone, email, password 컬럼을 null값 으로 업데이트합니다.

이용통계, 회원비율등의 통계정보 활용을 위해 DELETE처리하지 않았습니다.

성공시 상태코드 204 반환

<img width="1034" alt="스크린샷 2022-10-28 오전 8 45 25" src="https://user-images.githubusercontent.com/99805929/198417901-839635ed-71ea-4143-bbb3-6a7dc2341d73.png">


